### PR TITLE
Add xcframework support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -82,3 +82,9 @@ std = {features = ["jemalloc"]}
 [dependencies]
 std = {}
 ```
+
+# XCFrameworks
+
+fat binaries cannot contain multiple slices for the same architectures. That means using simulator x86_64 and macabi x86_64 in one fat binary doesn't work.
+Therefore, we can use a `xcframwork`. This PR adds `xcframework` support, however, there is an error that I don't understand yet.
+

--- a/make_fat.sh
+++ b/make_fat.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 
 # lipo together the different architectures into a universal 'fat' file
-xargo build --target x86_64-apple-ios-macabi --release
-xargo build --target aarch64-apple-ios --release
-lipo -create -output target/libtest1.a target/{aarch64-apple-ios,x86_64-apple-ios-macabi}/release/libtest1.a
+#xargo build --target x86_64-apple-ios-macabi --release
+#xargo build --target aarch64-apple-ios --release
+#xargo build --target x86_64-apple-ios --release
+
+set -x
+
+xcodebuild -create-xcframework \
+  -library target/aarch64-apple-ios/release/libtest1.a -headers test1_rust.h \
+  -library target/x86_64-apple-ios-macabi/release/libtest1.a -headers test1_rust.h \
+  -library target/x86_64-apple-ios/release/libtest1.a -headers test1_rust.h \
+  -output test1.xcframework
+
+set +x
+


### PR DESCRIPTION
Currently not working correctly. Error is:

```
The CodingKeys(stringValue: "SupportedPlatform", intValue: nil) is empty in library -arm64.
```