### PR TITLE
Use nightly Rust instead of `myrust`

### DIFF
--- a/make_fat.sh
+++ b/make_fat.sh
@@ -22,7 +22,7 @@ cargo +nightly build -Z build-std --target x86_64-apple-ios-macabi --release > /
 
 # ARM64 Catalyst
 echo "Building for Mac Catalyst ARM64..."
-cargo +myrust build -Z build-std --target aarch64-apple-ios-macabi --release > /dev/null 2>&1
+cargo +nightly build -Z build-std --target aarch64-apple-ios-macabi --release > /dev/null 2>&1
 
 # iOS
 echo "Building for ARM iOS..."


### PR DESCRIPTION
When running `make_fat.sh` I was seeing the following output as not all libraries had been compiled:

```
kim@mbp rust-catalyst-example % ./make_fat.sh
Building for iOS X86_64 (Simulator)...
Building for Mac Catalyst X86_64...
Building for Mac Catalyst ARM64...
Building for ARM iOS...
Building Fat Libaries
fatal error: /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/lipo: can't open input file: target/aarch64-apple-ios-macabi/release/libtest1.a (No such file or directory)
Wrote XcodeIntegration/XcodeIntegration/Rust/libtest1_ios.a
fatal error: /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/lipo: can't open input file: target/aarch64-apple-ios/release/libtest1.a (No such file or directory)
Wrote XcodeIntegration/XcodeIntegration/Rust/libtest1_mac.a
```

This change replaces `myrust` the standard nightly Rust so that it compiles for everyone. `myrust` was probably the Rust that contained https://github.com/rust-lang/rust/pull/77484.